### PR TITLE
adding new events/callback system

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
 			<p><strong>page_string</strong> - option, default: 'Page {current_page} of {max_page}'
 			<br />The string to base the input value on, no restrictions on the string, use <code>{current_page}</code> and <code>{max_page}</code> placeholders to allow the plugin to replace the respective numbers.</p>
 			<h3>Callbacks</h3>
-			<p><strong>paged</strong> - callback, params: page
+			<p><strong>paged</strong> - callback, params: event, page
 			<br />The paged callback is called when a valid page request has been made, the page variable simply contains the page requested.</p>
 			<h2 id="feedback">Feedback</h2>
 			<p>We're all on the planet to learn, if you feel improvements can be made to jqPagination <a href="mailto:hello@beneverard.co.uk">drop me an email</a>, <a href="http://twitter.com/ilmv">tweet me</a> or <a href="http://github.com/beneverard/jqPagination/">fork the project</a> and put in a pull request. If you want to report a bug head on over to the <a href="https://github.com/beneverard/jqPagination/issues">GitHub issues page</a>.</p>

--- a/js/jquery.jqpagination.js
+++ b/js/jquery.jqpagination.js
@@ -55,6 +55,10 @@
 				
 			}
 			
+			if (base.options.paged) {
+				base.$el.bind('jqPagination-paged', base.options.paged);
+			}
+			
 			// if the current-page data attribute is specified this takes priority
 			// over the options passed in, so long as it's a number
 			
@@ -170,11 +174,21 @@
 				base.setLinks(page);
 				
 				// fire the callback function with the current page
-				base.options.paged(page);
+				base.trigger('paged',page);
 				
 			}
 			
 		};
+		
+		base.trigger = function () {
+			var args = [],
+				i, len;
+
+			for(i = 0, len = arguments.length; i < len; i++){
+				args.push(arguments[i]);
+			}
+			base.$el.trigger('jqPagination-'+args.shift(), args);
+		}
 		
 		base.setCurrentPage = function (page) {
 			base.options.current_page = page;
@@ -239,7 +253,7 @@
 		link_string		: '',
 		max_page		: null,
 		page_string		: 'Page {current_page} of {max_page}',
-		paged			: function () {}
+		paged			: null
 	};
 
 	$.fn.jqPagination = function (options) {

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
 	$('.pagination').jqPagination({
 		link_string	: '/?page={page_number}',
 		max_page	: 40,
-		paged		: function(page) {
+		paged		: function(evt, page) {
 			$('.log').prepend('<li>Requested page ' + page + '</li>');
 		}
 	});


### PR DESCRIPTION
Rewrote the callback system to use native jQuery events/triggers.  Provides the advantage of being able to attach callbacks to the elements as events, and makes it easier to add new events to the plugin in the future.

Examples:

```
$('.paginate').jqPagination({
    paged: function(evt, page){
        console.log(page);
    }
});
$('.paginate').bind('jqPagination-paged', function(evt, page){});
```

Not backwards compatible, but easy for users to fix when updating.
