### PR TITLE
Reorder of updating max_page, current_page

### DIFF
--- a/js/jquery.jqpagination.js
+++ b/js/jquery.jqpagination.js
@@ -323,14 +323,14 @@
 
 					var prevent_paged = (options.trigger === false);
 
-					// if max_page property is set call setMaxPage
-					if(options.max_page !== undefined){
-						result = base.setMaxPage(options.max_page, prevent_paged);
-					}
-
 					// if current_page property is set call setPage
 					if(options.current_page !== undefined){
 						result = base.setPage(options.current_page, prevent_paged);
+					}
+
+					// if max_page property is set call setMaxPage
+					if(options.max_page !== undefined){
+						result = base.setMaxPage(options.max_page, prevent_paged);
 					}
 
 					// if we've not got a result fire an error and return false


### PR DESCRIPTION
This commit changes the order in which we set current_page and max_page
to ensure we always set current_page first.

This will prevent the error:

```
jqPagination: max_page lower than current_page
```

from occuring when we simultaneously update max_page and current_page
and max_page is less than the old current_page.
#### Steps to Reproduce in v1.3

``` javascript
.jqPagination('option', {
    max_page: 6,
    current_page: 2,
    trigger: false
});

.jqPagination('option', {
    max_page: 1,
    current_page: 1,
    trigger: false
});
```
